### PR TITLE
Windows installer

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,87 @@
+# Copyright 2021-2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: Build Windows Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: The tag to build
+      version:
+        type: string
+        required: true
+        description: The version to assign the installer
+permissions:
+  contents: read
+
+jobs:
+  build_installer:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        repository: 'openssl/openssl'
+        ref: ${{ github.event.inputs.tag }}
+        path: 'openssl'
+
+    - name: Setup directories 
+      run: |
+        mkdir _installer
+        mkdir openssl/_build64
+        mkdir openssl/_build32
+        dir
+    - name: download NSIS installer
+      uses: suisei-cn/actions-download-file@v1.6.0
+      with:
+        url: "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.10/nsis-3.10-setup.exe?ts=gAAAAABmMQBRN5Sft3h4QFuuBHnXpM1ogwBVwXxqccE-hQlHvAbv4FWo3xaP3npNcOL7TF9wV_XXe7jriMBJ5TTcP1e_7av5LA%3D%3D&r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fnsis%2Ffiles%2FNSIS%25203%2F3.10%2Fnsis-3.10-setup.exe%2Fdownload"
+        target: _installer/
+    - name: Install NSIS 3.10
+      working-directory: _installer
+      run:  .\nsis-3.10-setup.exe /s
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: win64
+    - uses: ilammy/setup-nasm@v1
+      with:
+        platform: win64
+    - name: config x64
+      working-directory: openssl/_build64
+      run: |
+        perl ..\Configure --banner=Configured no-makedepend enable-fips VC-WIN64A
+        perl configdata.pm --dump
+    - name: build x64 binaries
+      working-directory: openssl/_build64
+      run: nmake /S
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: win32
+    - uses: ilammy/setup-nasm@v1
+      with:
+        platform: win32
+    - name: config x32
+      working-directory: openssl/_build32
+      run: |
+        perl ..\Configure --banner=Configured no-makedepend enable-fips VC-WIN32
+        perl configdata.pm --dump
+    - name: build x32 binaries
+      working-directory: openssl/_build32
+      run: nmake /S
+    - name: build installer
+      working-directory: windows-installer
+      run:  nmake INSTVERSION=${{ github.event.inputs.version }} INSTBUILD32=../openssl/_build32 INSTBUILD64=../openssl/_build64 INSTLICENSE=../openssl/LICENSE.txt openssl-installer
+    - name: Upload installer as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: openssl-installer
+        path: windows-installer/openssl*.exe
+
+
+

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -41,7 +41,7 @@ jobs:
     - name: download NSIS installer
       uses: suisei-cn/actions-download-file@v1.6.0
       with:
-        url: "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.10/nsis-3.10-setup.exe?ts=gAAAAABmMQBRN5Sft3h4QFuuBHnXpM1ogwBVwXxqccE-hQlHvAbv4FWo3xaP3npNcOL7TF9wV_XXe7jriMBJ5TTcP1e_7av5LA%3D%3D&r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fnsis%2Ffiles%2FNSIS%25203%2F3.10%2Fnsis-3.10-setup.exe%2Fdownload"
+        url: "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.10/nsis-3.10-setup.exe"
         target: _installer/
     - name: Install NSIS 3.10
       working-directory: _installer

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -60,6 +60,9 @@ jobs:
     - name: build x64 binaries
       working-directory: openssl/_build64
       run: nmake /S
+    - name: install x64 binaries
+      working-directory: openssl/_build64
+      run: nmake /S DESTDIR=..\_install64 install
     - uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: win32
@@ -74,9 +77,12 @@ jobs:
     - name: build x32 binaries
       working-directory: openssl/_build32
       run: nmake /S
+    - name: install x32 binaries
+      working-directory: openssl/_build32
+      run: nmake /S DESTDIR=..\_install32 install
     - name: build installer
       working-directory: windows-installer
-      run:  nmake INSTVERSION=${{ github.event.inputs.version }} INSTBUILD32=../openssl/_build32 INSTBUILD64=../openssl/_build64 INSTLICENSE=../openssl/LICENSE.txt openssl-installer
+      run:  nmake INSTVERSION=${{ github.event.inputs.version }} INSTBUILD32=../openssl/_install32 INSTBUILD64=../openssl/_install64 INSTLICENSE=../openssl/LICENSE.txt openssl-installer
     - name: Upload installer as artifact
       uses: actions/upload-artifact@v4
       with:

--- a/windows-installer/Makefile
+++ b/windows-installer/Makefile
@@ -1,0 +1,27 @@
+NISNOPTS=""
+
+!IFDEF INSTVERSION
+NSISOPTS=$(NSISOPTS) /DVERSION=$(INSTVERSION)
+!ENDIF
+!IFDEF INSTBUILD32
+NSISOPTS=$(NSISOPTS) /DBUILD32=$(INSTBUILD32)
+!ENDIF
+!IFDEF INSTBUILD64
+NSISOPTS=$(NSISOPTS) /DBUILD64=$(INSTBUILD64)
+!ENDIF
+!IFDEF INSTLICENSE
+NSISOPTS=$(NSISOPTS) /DLICENSE_FILE=$(INSTLICENSE)
+!ENDIF
+
+openssl-installer: openssl.nsi
+	echo $(NSISOPTS)
+	makensis.exe $(NSISOPTS) .\openssl.nsi
+
+signed-openssl-installer: openssl.nsi
+	makecert.exe /n "CN=TestCompany" /r /h 0 /eku "1.3.6.1.5.5.7.3.3,1.3.6.1.4.1.311.10.3.13" /sv testcert.pvk testcert.cer
+	pvk2pfx.exe /pvk testcert.pvk /pi testpass /spc testcert.cer /pfx testcert.pfx /po testpass
+	makensis.exe $(NSISOPTS) /DSIGN=testcert.pfx /DSIGNPASS=testpass .\openssl.nsi
+
+clean:
+	del .\*.exe .\test*.*
+

--- a/windows-installer/Makefile
+++ b/windows-installer/Makefile
@@ -15,7 +15,7 @@ NSISOPTS=$(NSISOPTS) /DLICENSE_FILE=$(INSTLICENSE)
 
 openssl-installer: openssl.nsi
 	echo $(NSISOPTS)
-	makensis.exe $(NSISOPTS) .\openssl.nsi
+	makensis.exe $(NSISOPTS) /V4 .\openssl.nsi
 
 signed-openssl-installer: openssl.nsi
 	makecert.exe /n "CN=TestCompany" /r /h 0 /eku "1.3.6.1.5.5.7.3.3,1.3.6.1.4.1.311.10.3.13" /sv testcert.pvk testcert.cer

--- a/windows-installer/README.md
+++ b/windows-installer/README.md
@@ -68,11 +68,11 @@ Installer build options
 
 * `/DBUILD64`
   - Optional
-  - Path to the fully qualified 64 bit install directory (ex `c:\path\to\openssl\_install64`)
+  - Path to the fully qualified 64 bit install directory (ex `c:\path\to\openssl_install64`)
 
 * `/DBUILD32`
   - Optional
-  - Path to the fully qualified 32 bit build direcotry (ex `c:\path\to\openssl\_install32`)
+  - Path to the fully qualified 32 bit build direcotry (ex `c:\path\to\openssl_install32`)
 
 * `/DLICENSE_FILE`
   - Required

--- a/windows-installer/README.md
+++ b/windows-installer/README.md
@@ -4,9 +4,9 @@ Windows installer script
 Overview
 --------
 
-The windows installer script found in this directory is capable of building a
-windows installer executable capable of installing both 32 and 64 bit openssl
-binaries, along with their corresponding development headers
+The windows installer script found in this directory builds a windows installer
+executable capable of installing both 32 and 64 bit openssl binaries, along
+with their corresponding development headers
 
 Requirements
 ------------
@@ -22,23 +22,26 @@ Notes on Signing
 ----------------
 
 Installer signing is demonstrated here using self signed certificates. Do not
-use this signed code in a deployment as the generated certificate should not be
-trusted.  However, if you wish to observe this signed installer in operation,
-the generated certificate may be imported to the local trust store following the
-instructions
+use this signed code in a deployment as the self signed certificate should not
+be trusted.  However, if you wish to observe this signed installer in
+operation, the self signed certificate may be imported to the local trust store
+following the instructions
 [here](https://learn.microsoft.com/en-us/windows/win32/appxpkg/how-to-create-a-package-signing-certificate).
-at your own risk.
+Note: Importing this example certificate to the trust store is done at your own
+risk
 
 Installer Build Prerequisites
 -----------------------------
 
 1) Build Openssl from the parent of this directory:
-    a) cd /path/to/openssl/source/root
-    b) mkdir \_build64
-    c) cd \_build64
-    d) perl ..\Configure [options] VC-WIN64A
-    e) nmake
-    f) repeat steps a-e substituting \_build32 for \_build64 to build VC-WIN32
+    a) clone the openssl repository
+    b) cd path\to\openssl\
+    c) mkdir \_build64
+    d) cd \_build64
+    e) perl ..\Configure [options] VC-WIN64A
+    f) nmake
+    g) nmake DESTDIR=..\install64
+    h) repeat steps b-g substituting 32 for 64 to build VC-WIN32
 
 Building the installer
 ----------------------
@@ -47,28 +50,28 @@ From the windows-installer directory, the included makefile can build 2 targets
 1) openssl-installer
 2) signed-openssl-installer
 
-If option 1 is selected, the openssl-testversion-installer.exe file will be
+If target 1 is selected, the openssl-testversion-installer.exe file will be
 generated, pulling needed binaries from the ../\_build32 and ../\_build64
 directories.
 
-If option 2 is selected, A self signed certificate will be generated and used to
+If target 2 is selected, A self signed certificate will be generated and used to
 create the same installer, and digitally sign it.  Note that the Signtool
 utility requires a password for the generated private key be passed on the
 command line, while the MakeCert utility requires that it be entered via a gui
 popup window.  As such the Makefile is hard coded to use the password
-'testpass', which must be entered when prompted during certificate generation, or
-the signing process will fail.
+'testpass', which must be entered when prompted during certificate generation,
+or the signing process will fail.
 
 Installer build options
 -----------------------
 
 * /DBUILD64
   - Optional
-  - Path to the fully qualified 64 bit build directory (ex c:\path\to\openssl\_build64)
+  - Path to the fully qualified 64 bit install directory (ex c:\path\to\openssl\_install64)
 
 * /DBUILD32
   - Optional
-  - Path to the fully qualified 32 bit build direcotry (ex c:\path\to\openssl\_build32)
+  - Path to the fully qualified 32 bit build direcotry (ex c:\path\to\openssl\_install32)
 
 * /DLICENSE\_FILE
   - Required

--- a/windows-installer/README.md
+++ b/windows-installer/README.md
@@ -14,9 +14,9 @@ Requirements
 * [NSIS](https://nsis.sourceforge.io/Main_Page) version 3.0.8 or later
 * Windows 2022 or later
 * The Windows SDK
-  - The makecert.exe utility (to demonstrate installer signing)
-  - The Pvk2Pfx.exe utility (to demonstrate installer signing)
-  - The SignTool.exe utility (to demonstrate installer signing)
+  - The `makecert.exe` utility (to demonstrate installer signing)
+  - The `Pvk2Pfx.exe` utility (to demonstrate installer signing)
+  - The `SignTool.exe` utility (to demonstrate installer signing)
 
 Notes on Signing
 ----------------
@@ -32,7 +32,7 @@ risk
 
 Installer Build Prerequisites
 -----------------------------
-
+```
 1) Build Openssl from the parent of this directory:
     a) clone the openssl repository
     b) cd path\to\openssl\
@@ -42,6 +42,7 @@ Installer Build Prerequisites
     f) nmake
     g) nmake DESTDIR=..\install64
     h) repeat steps b-g substituting 32 for 64 to build VC-WIN32
+```
 
 Building the installer
 ----------------------
@@ -65,28 +66,28 @@ or the signing process will fail.
 Installer build options
 -----------------------
 
-* /DBUILD64
+* `/DBUILD64`
   - Optional
-  - Path to the fully qualified 64 bit install directory (ex c:\path\to\openssl\_install64)
+  - Path to the fully qualified 64 bit install directory (ex `c:\path\to\openssl\_install64`)
 
-* /DBUILD32
+* `/DBUILD32`
   - Optional
-  - Path to the fully qualified 32 bit build direcotry (ex c:\path\to\openssl\_install32)
+  - Path to the fully qualified 32 bit build direcotry (ex `c:\path\to\openssl\_install32`)
 
-* /DLICENSE\_FILE
+* `/DLICENSE_FILE`
   - Required
   - Path to the openssl LICENSE.TXT file
 
-* /DVERSION
+* `/DVERSION`
   - Required
   - Version number to insert in the openssl installer file name and meta data
   - Should match the version of openssl being built
 
-* /DSIGN
+* `/DSIGN`
   - Optional
   - Path to the fully qualified location of the code signing certificate pfx file
 
-* /DSIGNPASS
+* `/DSIGNPASS`
   - Required if /DSIGN is provided
   - Password string to decrypt the pfx file
 

--- a/windows-installer/README.md
+++ b/windows-installer/README.md
@@ -88,5 +88,5 @@ Installer build options
 
 * /DSIGNPASS
   - Required if /DSIGN is provided
-  - Password strign to decrypt the pfx file
+  - Password string to decrypt the pfx file
 

--- a/windows-installer/README.md
+++ b/windows-installer/README.md
@@ -1,0 +1,89 @@
+Windows installer script
+========================
+
+Overview
+--------
+
+The windows installer script found in this directory is capable of building a
+windows installer executable capable of installing both 32 and 64 bit openssl
+binaries, along with their corresponding development headers
+
+Requirements
+------------
+
+* [NSIS](https://nsis.sourceforge.io/Main_Page) version 3.0.8 or later
+* Windows 2022 or later
+* The Windows SDK
+  - The makecert.exe utility (to demonstrate installer signing)
+  - The Pvk2Pfx.exe utility (to demonstrate installer signing)
+  - The SignTool.exe utility (to demonstrate installer signing)
+
+Notes on Signing
+----------------
+
+Installer signing is demonstrated here using self signed certificates. Do not
+use this signed code in a deployment as the generated certificate should not be
+trusted.  However, if you wish to observe this signed installer in operation,
+the generated certificate may be imported to the local trust store following the
+instructions
+[here](https://learn.microsoft.com/en-us/windows/win32/appxpkg/how-to-create-a-package-signing-certificate).
+at your own risk.
+
+Installer Build Prerequisites
+-----------------------------
+
+1) Build Openssl from the parent of this directory:
+    a) cd /path/to/openssl/source/root
+    b) mkdir \_build64
+    c) cd \_build64
+    d) perl ..\Configure [options] VC-WIN64A
+    e) nmake
+    f) repeat steps a-e substituting \_build32 for \_build64 to build VC-WIN32
+
+Building the installer
+----------------------
+
+From the windows-installer directory, the included makefile can build 2 targets
+1) openssl-installer
+2) signed-openssl-installer
+
+If option 1 is selected, the openssl-testversion-installer.exe file will be
+generated, pulling needed binaries from the ../\_build32 and ../\_build64
+directories.
+
+If option 2 is selected, A self signed certificate will be generated and used to
+create the same installer, and digitally sign it.  Note that the Signtool
+utility requires a password for the generated private key be passed on the
+command line, while the MakeCert utility requires that it be entered via a gui
+popup window.  As such the Makefile is hard coded to use the password
+'testpass', which must be entered when prompted during certificate generation, or
+the signing process will fail.
+
+Installer build options
+-----------------------
+
+* /DBUILD64
+  - Optional
+  - Path to the fully qualified 64 bit build directory (ex c:\path\to\openssl\_build64)
+
+* /DBUILD32
+  - Optional
+  - Path to the fully qualified 32 bit build direcotry (ex c:\path\to\openssl\_build32)
+
+* /DLICENSE\_FILE
+  - Required
+  - Path to the openssl LICENSE.TXT file
+
+* /DVERSION
+  - Required
+  - Version number to insert in the openssl installer file name and meta data
+  - Should match the version of openssl being built
+
+* /DSIGN
+  - Optional
+  - Path to the fully qualified location of the code signing certificate pfx file
+
+* /DSIGNPASS
+  - Required if /DSIGN is provided
+  - Password strign to decrypt the pfx file
+

--- a/windows-installer/openssl.nsi
+++ b/windows-installer/openssl.nsi
@@ -26,8 +26,6 @@ Function .onInit
 	StrCpy $INSTDIR "C:\Program Files\openssl-${VERSION}"
 FunctionEnd
 
-# This section is run if installation of 32 bit binaries are selected
-
 !ifdef BUILD64
 # This section is run if installation of the 64 bit binaries are selectd
 SectionGroup "64 Bit Installation"
@@ -47,18 +45,18 @@ SectionGroupEnd
 !endif
 
 !ifdef BUILD32
-# This section is run if installation of the 64 bit binaries are selectd
+# This section is run if installation of the 32 bit binaries are selectd
 SectionGroup "32 Bit Installation"
 	Section "32 Bit Binaries"
-		SetOutPath $INSTDIR\x64\lib
+		SetOutPath $INSTDIR\x32\lib
 		File /r "${BUILD32}\Program Files\OpenSSL\lib\"
-		SetOutPath $INSTDIR\x64\bin
+		SetOutPath $INSTDIR\x32\bin
 		File /r "${BUILD32}\Program Files\OpenSSL\bin\"
 		SetOutPath "$INSTDIR\x64\Common Files"
 		File /r "${BUILD32}\Program Files\Common Files\"
 	SectionEnd
 	Section "x32 Development Headers"
-		SetOutPath $INSTDIR\x64\include
+		SetOutPath $INSTDIR\x324\include
 		File /r "${BUILD32}\Program Files\OpenSSL\include\"
 	SectionEnd
 SectionGroupEnd

--- a/windows-installer/openssl.nsi
+++ b/windows-installer/openssl.nsi
@@ -27,81 +27,48 @@ Function .onInit
 FunctionEnd
 
 # This section is run if installation of 32 bit binaries are selected
-!ifdef BUILD32
-SectionGroup "32 Bit Installation"
-	Section "32 Bit Binaries"
-		SetOutPath $INSTDIR\x32
-		File /NONFATAL ${BUILD32}\libcrypto-3.dll
-		File /NONFATAL ${BUILD32}\libssl-3.dll
-		File ${BUILD32}\libcrypto.lib
-		File ${BUILD32}\libssl.lib
-		File ${BUILD32}\apps\openssl.exe
-		SetOutPath $INSTDIR\x32\providers
-		File /NONFATAL ${BUILD32}\providers\fips.dll
-		File ${BUILD32}\providers\legacy.dll
-	SectionEnd
-	Section "x32 Development Headers"
-		SetOutPath $INSTDIR\x32\include\openssl
-		!tempfile headerlist
-		!system 'FOR /R "${BUILD32}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-		!include "${headerlist}"
-		!delfile "${headerlist}"
-		!undef headerlist
-
-		SetOutPath $INSTDIR\x32\include\crypto
-		!tempfile headerlist
-		!system 'FOR /R "${BUILD32}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-		!include "${headerlist}"
-		!delfile "${headerlist}"
-		!undef headerlist
-
-		SetOutPath $INSTDIR\x32\include\internal
-		!tempfile headerlist
-		!system 'FOR /R "${BUILD32}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-		!include "${headerlist}"
-		!delfile "${headerlist}"
-		!undef headerlist
-	SectionEnd
-SectionGroupEnd
-!endif
 
 !ifdef BUILD64
 # This section is run if installation of the 64 bit binaries are selectd
 SectionGroup "64 Bit Installation"
 	Section "64 Bit Binaries"
-		SetOutPath $INSTDIR\x64
-		File /NONFATAL ${BUILD64}\libcrypto-3-x64.dll
-		File /NONFATAL ${BUILD64}\libssl-3-x64.dll
-		File ${BUILD64}\libcrypto.lib
-		File ${BUILD64}\libssl.lib
-		File ${BUILD64}\apps\\openssl.exe
-		SetOutPath $INSTDIR\x64\providers
-		File /NONFATAL ${BUILD64}\providers\fips.dll
-		File ${BUILD64}\providers\legacy.dll
+		SetOutPath $INSTDIR\x64\lib
+		File /r "${BUILD64}\Program Files\OpenSSL\lib\"
+		SetOutPath $INSTDIR\x64\bin
+		File /r "${BUILD64}\Program Files\OpenSSL\bin\"
+		SetOutPath "$INSTDIR\x64\Common Files"
+		File /r "${BUILD64}\Program Files\Common Files\"
 	SectionEnd
 	Section "x64 Development Headers"
-		SetOutPath $INSTDIR\x64\include\openssl
-		!tempfile headerlist
-		!system 'FOR /R "${BUILD64}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-		!include "${headerlist}"
-		!delfile "${headerlist}"
-		!undef headerlist
-
-		SetOutPath $INSTDIR\x64\include\crypto
-		!tempfile headerlist
-		!system 'FOR /R "${BUILD64}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-		!include "${headerlist}"
-		!delfile "${headerlist}"
-		!undef headerlist
-
-		SetOutPath $INSTDIR\x64\include\internal
-		!tempfile headerlist
-		!system 'FOR /R "${BUILD64}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-		!include "${headerlist}"
-		!delfile "${headerlist}"
-		!undef headerlist
+		SetOutPath $INSTDIR\x64\include
+		File /r "${BUILD64}\Program Files\OpenSSL\include\"
 	SectionEnd
 SectionGroupEnd
+!endif
+
+!ifdef BUILD32
+# This section is run if installation of the 64 bit binaries are selectd
+SectionGroup "32 Bit Installation"
+	Section "32 Bit Binaries"
+		SetOutPath $INSTDIR\x64\lib
+		File /r "${BUILD32}\Program Files\OpenSSL\lib\"
+		SetOutPath $INSTDIR\x64\bin
+		File /r "${BUILD32}\Program Files\OpenSSL\bin\"
+		SetOutPath "$INSTDIR\x64\Common Files"
+		File /r "${BUILD32}\Program Files\Common Files\"
+	SectionEnd
+	Section "x32 Development Headers"
+		SetOutPath $INSTDIR\x64\include
+		File /r "${BUILD32}\Program Files\OpenSSL\include\"
+	SectionEnd
+SectionGroupEnd
+!endif
+
+!ifdef BUILD64
+Section "Documentation"
+	SetOutPath $INSTDIR\html
+	File /r "${BUILD64}\Program Files\OpenSSL\html\"
+SectionEnd
 !endif
 
 # Always install the uninstaller
@@ -119,15 +86,14 @@ SectionEnd
 !insertmacro MUI_PAGE_LICENSE ${LICENSE_FILE}
 
 Function CheckRunUninstaller
-	IfFileExists $INSTDIR\uninstall.exe 0 +2
-	ExecWait '"$INSTDIR\uninstall.exe" /S _?=$INSTDIR'
+        ifFileExists $INSTDIR\uninstall.exe 0 +2
+        ExecWait "$INSTDIR\uninstall.exe /S _?=$INSTDIR"
 FunctionEnd
+!insertmacro MUI_PAGE_COMPONENTS
 
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE CheckRunUninstaller
 !define MUI_DIRECTORYPAGE_TEXT_DESTINATION "Installation Directory"
 !insertmacro MUI_PAGE_DIRECTORY
-
-!insertmacro MUI_PAGE_COMPONENTS
 
 !insertmacro MUI_PAGE_INSTFILES
 

--- a/windows-installer/openssl.nsi
+++ b/windows-installer/openssl.nsi
@@ -1,0 +1,147 @@
+
+######################################################
+# NSIS windows installer script file
+# Requirements: NSIS 3.0 must be installed with the MUI plugin
+# Usage notes:
+# This script expects to be executed from the directory it is
+# currently stored in.  It expects a 32 bit and 64 bit windows openssl
+# build to be present in the ..\${BUILD32} and ..\${BUILD64} directories
+# respectively
+# ####################################################
+
+!include "MUI.nsh"
+
+!define PRODUCT_NAME "OpenSSL"
+
+# The name of the output file we create when building this
+# NOTE version is passed with the /D option on the command line
+OutFile "openssl-${VERSION}-installer.exe"
+
+# The name that will appear in the installer title bar
+NAME "${PRODUCT_NAME} ${VERSION}"
+
+ShowInstDetails show
+
+Function .onInit
+	StrCpy $INSTDIR "C:\Program Files\openssl-${VERSION}"
+FunctionEnd
+
+# This section is run if installation of 32 bit binaries are selected
+!ifdef BUILD32
+SectionGroup "32 Bit Installation"
+	Section "32 Bit Binaries"
+		SetOutPath $INSTDIR\x32
+		File /NONFATAL ${BUILD32}\libcrypto-3.dll
+		File /NONFATAL ${BUILD32}\libssl-3.dll
+		File ${BUILD32}\libcrypto.lib
+		File ${BUILD32}\libssl.lib
+		File ${BUILD32}\apps\openssl.exe
+		SetOutPath $INSTDIR\x32\providers
+		File /NONFATAL ${BUILD32}\providers\fips.dll
+		File ${BUILD32}\providers\legacy.dll
+	SectionEnd
+	Section "x32 Development Headers"
+		SetOutPath $INSTDIR\x32\include\openssl
+		!tempfile headerlist
+		!system 'FOR /R "${BUILD32}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+
+		SetOutPath $INSTDIR\x32\include\crypto
+		!tempfile headerlist
+		!system 'FOR /R "${BUILD32}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+
+		SetOutPath $INSTDIR\x32\include\internal
+		!tempfile headerlist
+		!system 'FOR /R "${BUILD32}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+	SectionEnd
+SectionGroupEnd
+!endif
+
+!ifdef BUILD64
+# This section is run if installation of the 64 bit binaries are selectd
+SectionGroup "64 Bit Installation"
+	Section "64 Bit Binaries"
+		SetOutPath $INSTDIR\x64
+		File /NONFATAL ${BUILD64}\libcrypto-3-x64.dll
+		File /NONFATAL ${BUILD64}\libssl-3-x64.dll
+		File ${BUILD64}\libcrypto.lib
+		File ${BUILD64}\libssl.lib
+		File ${BUILD64}\apps\\openssl.exe
+		SetOutPath $INSTDIR\x64\providers
+		File /NONFATAL ${BUILD64}\providers\fips.dll
+		File ${BUILD64}\providers\legacy.dll
+	SectionEnd
+	Section "x64 Development Headers"
+		SetOutPath $INSTDIR\x64\include\openssl
+		!tempfile headerlist
+		!system 'FOR /R "${BUILD64}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+
+		SetOutPath $INSTDIR\x64\include\crypto
+		!tempfile headerlist
+		!system 'FOR /R "${BUILD64}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+
+		SetOutPath $INSTDIR\x64\include\internal
+		!tempfile headerlist
+		!system 'FOR /R "${BUILD64}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+	SectionEnd
+SectionGroupEnd
+!endif
+
+# Always install the uninstaller
+Section 
+	WriteUninstaller $INSTDIR\uninstall.exe
+SectionEnd
+
+# This is run on uninstall
+Section "Uninstall"
+	RMDIR /r $INSTDIR
+SectionEnd
+
+!insertmacro MUI_PAGE_WELCOME
+
+!insertmacro MUI_PAGE_LICENSE ${LICENSE_FILE}
+
+Function CheckRunUninstaller
+	IfFileExists $INSTDIR\uninstall.exe 0 +2
+	ExecWait '"$INSTDIR\uninstall.exe" /S _?=$INSTDIR'
+FunctionEnd
+
+!define MUI_PAGE_CUSTOMFUNCTION_LEAVE CheckRunUninstaller
+!define MUI_DIRECTORYPAGE_TEXT_DESTINATION "Installation Directory"
+!insertmacro MUI_PAGE_DIRECTORY
+
+!insertmacro MUI_PAGE_COMPONENTS
+
+!insertmacro MUI_PAGE_INSTFILES
+
+!insertmacro MUI_UNPAGE_WELCOME
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
+
+!ifdef SIGN
+!define OutFileSignSHA1 "SignTool.exe sign /f ${SIGN} /p ${SIGNPASS} /fd sha1 /t http://timestamp.comodoca.com /v"
+!define OutFileSignSHA256 "SignTool.exe sign /f ${SIGN} /p ${SIGNPASS} /fd sha256 /tr http://timestamp.comodoca.com?td=sha256 /td sha256 /v"
+
+!finalize "${OutFileSignSHA1} .\openssl-${VERSION}-installer.exe"
+!finalize "${OutFileSignSHA256} .\openssl-${VERSION}-installer.exe"
+!endif


### PR DESCRIPTION
As part of openssl/project#20 I've created this draft PR to propose a windows installer framework. The installer currently:

* Allows for the installation of 32 bit and 64 bit x86 binaries and supporting libraries, including the fips and legacy proiders (selectable at installer-run-time)
* Allows for the installation of development headers (selectable at installer-run-time)
* Creates an uninstaller
* Allows for the side-by-side installation of multiple openssl versions (target install directory selectable at installer-run-time, defaulting to c:\Program Files\openssl-)
* Demonstrates installer signing using Microsofts code signing utilities with a generated self-signed certificate
* Includes a manually triggered github workflow to build the installer on demand, and could be enhanced to do a nightly build
* Includes a nmake makefile to demonstrate local building
* 
This PR expressly omits any official building of the installer, as we need to determine how we would want to manage code signing certificates, as well as how we want to incorporate the building and releasing of the installer as part of our release process, but I think the installer itself is in pretty good shape. My proposal would be to incorporate this PR in 3.4 and target 3.5 for integrating a signed installer release into the 3.5 development cycle